### PR TITLE
Upgraded to version 2 of apis.guru.

### DIFF
--- a/src/hub/index.html
+++ b/src/hub/index.html
@@ -896,7 +896,7 @@
             function loadList () {
                 return $http({
                     method: 'GET',
-                    url: 'https://apis-guru.github.io/api-models/api/v1/list.json',
+                    url: 'https://api.apis.guru/v2/list.json',
                     cache: HubCache
                 });
             }


### PR DESCRIPTION
With the old version of the apis.guru api the hub did not work anymore.
